### PR TITLE
debian: mark audioflingerglue-dev as Multi-Arch: foreign

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,4 @@
-audioflingerglue (0.1ubports1) UNRELEASED; urgency=medium
+audioflingerglue (0.1ubports1) xenial; urgency=medium
 
   * No change rebuild to publish sources to ubports repo 
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+audioflingerglue (0.1ubports2) xenial; urgency=medium
+
+  * Mark audioflingerglue-dev as Multi-Arch: foreign
+
+ -- Ratchanan Srirattanamet <peathot@hotmail.com>  Wed, 18 Sep 2019 22:48:42 +0700
+
 audioflingerglue (0.1ubports1) xenial; urgency=medium
 
   * No change rebuild to publish sources to ubports repo 

--- a/debian/control
+++ b/debian/control
@@ -8,4 +8,5 @@ Maintainer: Marius Gripsgard <marius@ubports.com>
 Package: audioflingerglue-dev
 Priority: optional
 Architecture: all
+Multi-Arch: foreign
 Description: Audioflinger glue development files


### PR DESCRIPTION
It should be safe because all it provides is a header and a source
file. This fixes cross-building pulseaudio.

Also fixup changelog entry.