### PR TITLE
Revert "debian: mark audioflingerglue-dev as Multi-Arch: foreign"

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -8,5 +8,4 @@ Maintainer: Marius Gripsgard <marius@ubports.com>
 Package: audioflingerglue-dev
 Priority: optional
 Architecture: any
-Multi-Arch: foreign
 Description: Audioflinger glue development files


### PR DESCRIPTION
We now process hybris.c for each architecture, thus no longer
Multi-Arch: foreign. Leaving it in can cause i.e. the amd64 version to
satisfy build dependencies for armhf build, which breaks library lookup.

This partially reverts commit 8808b95d925ea261c8882d1e379d57ffba1fdba0.